### PR TITLE
- updated instructions to run jekyll

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,11 @@ Never use # (h1) as it’s reserved for the title. Don’t repeat the title in t
 Write your article in Markdown, save it to `_posts` folder.
 If this is your first post, prepare your Bio (see above for details).
 
+If you're Mac user and you haven't installed Ruby yourself, then you could perform following steps:
+* `brew install ruby`
+* add `export PATH="/usr/local/opt/ruby/bin:$PATH"` into your `.bashrc`/`.zshrc`
+
+
 Install needed gems: `bundle install --path vendor/bundle`
 
 Launch the site using [Jekyll](https://help.github.com/articles/using-jekyll-with-pages),

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gem "github-pages", "~> 207", group: :jekyll_plugins
 gem 'jekyll-redirect-from'
 gem 'jekyll-sitemap'
 gem 'jekyll-relative-links'
-gem "webrick"
+gem 'webrick'
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
@@ -12,4 +12,3 @@ platforms :mingw, :x64_mingw, :mswin, :jruby do
   gem "tzinfo-data"
   gem 'wdm', '>= 0.1.0'
 end
-

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ gem "github-pages", "~> 207", group: :jekyll_plugins
 gem 'jekyll-redirect-from'
 gem 'jekyll-sitemap'
 gem 'jekyll-relative-links'
+gem "webrick"
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.


### PR DESCRIPTION
instructions to run jekyll in MacOs, missing webrick package from Gemfile