### PR TITLE
Introduce maximum line length to Markdown files for better readability

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,8 @@
 {
     "default": true,
-    "MD013": false,
+    "MD013": {
+        "line_length": 120
+    },
     "MD022": false,
     "MD026": false,
     "MD032": false,


### PR DESCRIPTION
Na ten moment nawet całe akapity potrafią być napisane w jednej linijce co utrudnia review bo Github sam łamie je w losowych miejscach + sugestie zmian są mniej czytelne. Wprowadzając tą zmianę nie ruszamy istniejących postów, ale te nowe będą już musiały przejść odpowiednie sprawdzenie.

Konkretna wartość do dogadania, `120` to jest górny limit który zazwyczaj mamy w kodzie.

Jeśli jest taka potrzeba, to zasadę można wyłączyć dla danego pliku zgodnie z https://github.com/DavidAnson/markdownlint#configuration